### PR TITLE
TypeError: Struct() argument 1 must be string, not unicode

### DIFF
--- a/pynba/core/message.py
+++ b/pynba/core/message.py
@@ -53,7 +53,7 @@ def write_uvarint(file, value):
 
 
 def write_float(file, value):
-    packed_value = struct.pack('<f', value)
+    packed_value = struct.pack(str('<f'), value)
     file.write(packed_value)
 
 


### PR DESCRIPTION
Very strange bug. Any idea?

```
In [5]: timer.stop()
Out[5]: <Timer({'foo': 'bar'}) elapsed:4.83570098877>

In [6]: monitor.send()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/srv/pinba/demo/venv/local/lib/python2.7/site-packages/django/core/management/commands/shell.pyc in <module>()
----> 1 monitor.send()

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/util/script.pyc in send(self)
    116             memory_footprint=None,
    117             schema=None,
--> 118             tags=self.collector.tags
    119         )
    120

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/core/reporter.so in pynba.core.reporter.Reporter.__call__ (pynba/core/reporter.c:2798)()

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/core/reporter.so in pynba.core.reporter.Reporter_prepare (pynba/core/reporter.c:2291)()

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/core/reporter.so in pynba.core.reporter.Reporter_prepare (pynba/core/reporter.c:2028)()

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/core/message.pyc in dumps(**attrs)
     89                 wire_type = 5
     90                 write_tag(file, field.tag, wire_type)
---> 91                 write_float(file, value)
     92                 continue
     93             elif field.type == 'string':

/srv/pinba/demo/venv/local/lib/python2.7/site-packages/pynba/core/message.pyc in write_float(file, value)
     54
     55 def write_float(file, value):
---> 56     packed_value = struct.pack('<f', value)
     57     file.write(packed_value)
     58

TypeError: Struct() argument 1 must be string, not unicode
```
# python -V

Python 2.7.3
# uname -a

Linux hostname 3.2.0-58-virtual #88-Ubuntu SMP Tue Dec 3 17:58:13 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
# cat /etc/lsb-release

DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
